### PR TITLE
Limit requests to avoid hitting rate limits (#4)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,8 @@ Imports:
     raster,
     httr,
     jsonlite,
-    progress
+    progress,
+    ratelimitr
 License: CC0
 Encoding: UTF-8
 LazyData: true

--- a/R/rate_limited_GET.R
+++ b/R/rate_limited_GET.R
@@ -1,0 +1,15 @@
+# based on https://mapzen.com/documentation/overview/#rate-limits
+# limits for keyless access are 1/second and 6/minute
+# see issue #4
+mapzen_elev_GET_nokey <- ratelimitr::limit_rate(
+  httr::GET, 
+  ratelimitr::rate(n = 1, period = 1), ratelimitr::rate(n = 5, period = 75))
+
+# based on https://mapzen.com/documentation/overview/#rate-limits
+# limits for valid keyholders are 2/second and 20K/day
+# this function will only enforce the 2/second limit
+# see issue #4
+mapzen_elev_GET_withkey <- ratelimitr::limit_rate(
+  httr::GET,
+  ratelimitr::rate(n = 2, period = 1)
+)

--- a/tests/testthat/test-get_elev_point.R
+++ b/tests/testthat/test-get_elev_point.R
@@ -14,11 +14,8 @@ test_that("get_elev_point returns correctly", {
   #skip_on_cran()
   
   mz_df <- get_elev_point(locations = pt_df,prj = ll_prj, api_key = NULL)
-  Sys.sleep(10)
   mz_sp <- get_elev_point(locations = sp_big, api_key = NULL)
-  Sys.sleep(10)
   mz_sp_prj <- get_elev_point(locations = sp_sm_prj, api_key = NULL)
-  Sys.sleep(10)
   mz_sp_200 <- get_elev_point(locations = sp_big[1:200,], api_key = NULL)
   epqs_df <- get_elev_point(locations = pt_df, prj = ll_prj, src = "epqs")
   epqs_sp <- get_elev_point(locations = sp_sm, src = "epqs")

--- a/tests/testthat/test-get_elev_point.R
+++ b/tests/testthat/test-get_elev_point.R
@@ -14,8 +14,11 @@ test_that("get_elev_point returns correctly", {
   #skip_on_cran()
   
   mz_df <- get_elev_point(locations = pt_df,prj = ll_prj, api_key = NULL)
+  Sys.sleep(10)
   mz_sp <- get_elev_point(locations = sp_big, api_key = NULL)
+  Sys.sleep(10)
   mz_sp_prj <- get_elev_point(locations = sp_sm_prj, api_key = NULL)
+  Sys.sleep(10)
   mz_sp_200 <- get_elev_point(locations = sp_big[1:200,], api_key = NULL)
   epqs_df <- get_elev_point(locations = pt_df, prj = ll_prj, src = "epqs")
   epqs_sp <- get_elev_point(locations = sp_sm, src = "epqs")

--- a/tests/testthat/test-get_elev_raster.R
+++ b/tests/testthat/test-get_elev_raster.R
@@ -15,14 +15,11 @@ test_that("get_elev_raster returns correctly", {
   
   mz_df <- get_elev_raster(locations = pt_df,prj = ll_prj, api_key = NULL, 
                            z = 6)
-  Sys.sleep(1)
   mz_sp <- get_elev_raster(locations = sp_sm, api_key = NULL, 
                            z = 6)
-  Sys.sleep(1)
   mz_sp_prj <- get_elev_raster(locations = sp_sm_prj, api_key = NULL, 
                                z = 6)
   
-  Sys.sleep(1)
   onetile <- get_elev_raster(locations = sp_sm[1,], api_key = NULL, 
                                z = 6)
   

--- a/tests/testthat/test-internal.R
+++ b/tests/testthat/test-internal.R
@@ -41,8 +41,11 @@ test_that("loc_check errors correctly", {
 test_that("loc_check assigns prj correctly",{
   expect_equal(proj4string(get_elev_point(locations = sp_sm, prj = ll_prj)),
                ll_prj)
+  Sys.sleep(10)
   expect_equal(proj4string(get_elev_point(locations = spdf_sm, prj = ll_prj)),
                ll_prj)
+  Sys.sleep(10)
   expect_equal(proj4string(get_elev_point(locations = rast, prj = ll_prj)),
                ll_prj)
+  Sys.sleep(10)
 })

--- a/tests/testthat/test-internal.R
+++ b/tests/testthat/test-internal.R
@@ -41,10 +41,8 @@ test_that("loc_check errors correctly", {
 test_that("loc_check assigns prj correctly",{
   expect_equal(proj4string(get_elev_point(locations = sp_sm, prj = ll_prj)),
                ll_prj)
-  Sys.sleep(10)
   expect_equal(proj4string(get_elev_point(locations = spdf_sm, prj = ll_prj)),
                ll_prj)
-  Sys.sleep(10)
   expect_equal(proj4string(get_elev_point(locations = rast, prj = ll_prj)),
                ll_prj)
 })


### PR DESCRIPTION
Ok, so I:
1) forked and ran unit tests. Everything passed
2) removed the `Sys.sleep` naps from the unit tests. After that, tests failed every time. 
3) re-directed the calls to `httr::GET` in `get_mapzen_elev` to the new (rate-limited) `mapzen_elev_GET_*` functions (one for requests without a key, one for requests with a key). 

The tests are once again passing, but now there are no naps in the unit tests (I didn't modify the vignette, though). 

A couple of concerns I noticed, though: 
1) Unit testing now has all of the joy associated with testing functions that have side effects. In particular, I have a process of editing stuff, running code in the REPL, and when satisfied, doing a `devtools::load_all` and then running the unit tests. Unfortunately, re-sourcing the code means that the "timer" involved is effectively being reset. And suddenly you hit rate limits because Mapzen still remembers the history from before you re-sourced. So far `devtools::check` runs with 0 errors/warnings/notes, but I'm wondering if there could ever be issues because that process builds vignettes and then a little later runs the unit tests, and presumably when running the unit tests it has no knowledge of the requests that were made to build the vignettes. In my own packages I've taken to splitting out the functions that (a) build the request URL and (b) actually make the request, so that I can test the former without these concerns. 
2) The [Mapzen documentation](https://mapzen.com/documentation/overview/#rate-limits) says that for keyless access, the rate limits for all services are 1 request per second and 6 per minute. But when I limited the functions accordingly, I would still occasionally get a 429 rate limit error. After checking with a stopwatch and even crazily googling how many seconds are in one minute, I satisfied myself that the problem wasn't that the functions were being called too often. I finally settled on changing the "without API key" limit to 5 per 75 seconds, which seems to be working, but I have no explanation for why 6 per 60 was not nor why 5 per 75 does. I also did my own tests with my API key to check the "with key" limits, and was able to make hundreds of requests without ever getting a rate limit error. 

Hope this helps!