### PR TITLE
Update URLs in man

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,8 @@ Title: Access Elevation Data from Various APIs
 Version: 0.2.0
 Authors@R: c(person("Jeffrey", "Hollister", email = "hollister.jeff@epa.gov", 
                   role = c("aut", "cre")),
-             person("Tarak","Shah", role = "ctb"))    
+             person("Tarak","Shah", role = "ctb"),
+             person("Alec L.", "Robitaille", role = "ctb", comment = c(ORCID = "0000-0002-4706-1762")))
 URL: https://www.github.com/jhollist/elevatr
 BugReports: https://github.com/jhollist/elevatr/issues
 Maintainer: Jeffrey Hollister <hollister.jeff@epa.gov>

--- a/R/get_elev_point.R
+++ b/R/get_elev_point.R
@@ -28,7 +28,7 @@
 #'            defualt of 5 is used, but this uses a raster with a large ~4-5 km 
 #'            pixel.  Additionally, the source data changes as zoom levels 
 #'            increase.  
-#'            Read \url{https://mapzen.com/documentation/terrain-tiles/data-sources/#what-is-the-ground-resolution} 
+#'            Read \url{https://github.com/tilezen/joerd/blob/master/docs/data-sources.md#what-is-the-ground-resolution} 
 #'            for details.  
 #' @return Function returns a \code{SpatialPointsDataFrame} or \code{sf} object 
 #'         in the projection specified by the \code{prj} argument.
@@ -145,7 +145,7 @@ get_epqs <- function(locations, units = c("meters","feet")){
 #' @param z The zoom level to return.  The zoom ranges from 1 to 14.  Resolution
 #'           of the resultant raster is determined by the zoom and latitude.  For 
 #'           details on zoom and resolution see the documentation from Mapzen at 
-#'           \url{https://mapzen.com/documentation/terrain-tiles/data-sources/#what-is-the-ground-resolution}.  
+#'           \url{https://github.com/tilezen/joerd/blob/master/docs/data-sources.md#what-is-the-ground-resolution}.  
 #'           default value is 5 is supplied.   
 #' @param units Character string of either meters or feet. Conversions for 
 #'              'aws' are handled in R as the AWS terrain tiles are served in 

--- a/R/get_elev_raster.R
+++ b/R/get_elev_raster.R
@@ -11,7 +11,7 @@
 #' @param z  The zoom level to return.  The zoom ranges from 1 to 14.  Resolution
 #'           of the resultant raster is determined by the zoom and latitude.  For 
 #'           details on zoom and resolution see the documentation from Mapzen at 
-#'           \url{https://mapzen.com/documentation/terrain-tiles/data-sources/#what-is-the-ground-resolution}                 
+#'           \url{https://github.com/tilezen/joerd/blob/master/docs/data-sources.md#what-is-the-ground-resolution                 
 #' @param prj A PROJ.4 string defining the projection of the locations argument. 
 #'            If a \code{sp} or \code{raster} object is provided, the PROJ.4 
 #'            string will be taken from that.  This argument is required for a 
@@ -105,7 +105,7 @@ get_elev_raster <- function(locations, z, prj = NULL,src = c("aws"),
 #' @param z The zoom level to return.  The zoom ranges from 1 to 14.  Resolution
 #'          of the resultant raster is determined by the zoom and latitude.  For 
 #'          details on zoom and resolution see the documentation from Mapzen at 
-#'          \url{https://mapzen.com/documentation/terrain-tiles/data-sources/#what-is-the-ground-resolution}
+#'          \url{https://github.com/tilezen/joerd/blob/master/docs/data-sources.md#what-is-the-ground-resolution}
 #' @param prj PROJ.4 string for input bbox 
 #' @param expand A numeric value of a distance, in map units, used to expand the
 #'               bounding box that is used to fetch the terrain tiles. This can 

--- a/R/get_elev_raster.R
+++ b/R/get_elev_raster.R
@@ -38,7 +38,7 @@
 #'         specified by the \code{prj} argument.
 #' @details Currently, the \code{get_elev_raster} utilizes only the 
 #'          Amazon Web Services 
-#'          (\url{https://aws.amazon.com/public-datasets/terrain/}) terrain 
+#'          (\url{https://registry.opendata.aws/terrain-tiles/}) terrain 
 #'          tiles.  Versions of \code{elevatr} 0.1.4 or earlier had options for 
 #'          the Mapzen terrain tiles.  Mapzen data is no longer available.  
 #'          Support for the replacment Nextzen tiles is not currently available


### PR DESCRIPTION
Hello, 
Just about to use your package when I noticed the links in the man were getting redirected to the root of [a GitHub repo](https://github.com/tilezen/joerd/). 

I fixed the ground resolution description from https://mapzen.com/documentation/terrain-tiles/data-sources/#what-is-the-ground-resolution to https://github.com/tilezen/joerd/blob/master/docs/data-sources.md#what-is-the-ground-resolution. 

There's also a link in get_elev_raster for the open terrain data updated to https://registry.opendata.aws/terrain-tiles/. 

I'm not exactly sure where https://mapzen.com/documentation/terrain-tiles/ was pointing (in `@source`). 

(Excuse the typo in the first commit, I missed the 'get_' in 'get_elev_point.R')

Thanks!